### PR TITLE
Handle destroySubviews being called with `null`

### DIFF
--- a/dist/subview.js
+++ b/dist/subview.js
@@ -85,6 +85,10 @@
       this.__subviews = _2['default'].difference(this.__subviews, subviews);
 
       _2['default'].each(subviews, function (subview) {
+        if (!subview || !_2['default'].isFunction(subview.remove)) {
+          return;
+        }
+
         subview.remove();
       });
     },

--- a/src/subview.js
+++ b/src/subview.js
@@ -65,6 +65,10 @@ export default {
     this.__subviews = _.difference(this.__subviews, subviews);
 
     _.each(subviews, (subview) => {
+      if (!subview || !_.isFunction(subview.remove)) {
+        return;
+      }
+
       subview.remove();
     });
   },

--- a/test/subview_test.js
+++ b/test/subview_test.js
@@ -66,11 +66,27 @@ function testChildMixin(ChildMixin) {
           spyOn(subview, 'remove');
         });
 
-        it('should correctly just provided subview', () => {
+        it('should correctly remove just provided subview', () => {
           view.destroySubviews(secondSubview);
 
           expect(secondSubview.remove).toHaveBeenCalled();
           expect(subview.remove).not.toHaveBeenCalled();
+          expect(subviewCount(view)).toBe(1);
+        });
+
+        it('should not destroy any subviews if non-view was provided', () => {
+          view.destroySubviews(null);
+
+          expect(subview.remove).not.toHaveBeenCalled();
+          expect(secondSubview.remove).not.toHaveBeenCalled();
+          expect(subviewCount(view)).toBe(2);
+        });
+
+        it ('should ignore non-views if any are present in the array provided in multi-signature', () => {
+          view.destroySubviews([subview, null]);
+
+          expect(subview.remove).toHaveBeenCalled();
+          expect(secondSubview.remove).not.toHaveBeenCalled();
           expect(subviewCount(view)).toBe(1);
         });
 


### PR DESCRIPTION
Prevent wrong behavior when `destroySubviews` is called with `null`.
Previously this would throw `TypeError: 'null' is not an object`:

``` js
view.destroySubviews(null);
```

Now it correctly does not destroy any views.
